### PR TITLE
MBS-10061: Restrict svgcode processing

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -91,6 +91,12 @@ function learningmap_update_instance($data): int {
         );
     }
 
+    // Don't save changes to svgcode and placestore if the general part of the editing form was not shown.
+    if (!empty($data->showonly) && $data->showonly != 'general') {
+        unset($data->svgcode);
+        unset($data->placestore);
+    }
+
     return $DB->update_record("learningmap", $data);
 }
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -151,8 +151,6 @@ class mod_learningmap_mod_form extends moodleform_mod {
 
         $mform->closeHeaderBefore('header');
 
-        $PAGE->requires->js_call_amd('mod_learningmap/learningmap', 'init');
-
         $this->standard_coursemodule_elements();
 
         $this->add_action_buttons(true, null, null);
@@ -166,6 +164,12 @@ class mod_learningmap_mod_form extends moodleform_mod {
      * @return void
      */
     public function definition_after_data() {
+        global $PAGE;
+        $data = $this->get_data();
+        // Only load the javascript for the map editor if the general part of the form is shown.
+        if (empty($data->showonly) || $data->showonly == 'general') {
+            $PAGE->requires->js_call_amd('mod_learningmap/learningmap', 'init');
+        }
         $this->_form->_elements[$this->_form->_elementIndex['groupmode']]->removeOption(VISIBLEGROUPS);
         parent::definition_after_data();
     }
@@ -295,8 +299,10 @@ class mod_learningmap_mod_form extends moodleform_mod {
      * @return void
      */
     public function data_postprocessing($data): void {
-        // As this form is also used for setting the default completion settings, there might not be an actual learningmap.
-        if (!empty($data->svgcode)) {
+        // Only change anything to the SVG code if the general part of the form is shown and
+        // there is actual svgcode (which is not the case if the form is used for changing
+        // default completion settings).
+        if (!empty($data->svgcode) && (empty($data->showonly) || $data->showonly == 'general')) {
             $mapworker = new mapworker(
                 $data->svgcode,
                 json_decode($data->placestore, true)


### PR DESCRIPTION
When using modedit forms that use showonly parameter, svgcode is modified in a not intended way (map size gets set to 0 x 0, so no map is visible anymore). This patch avoids that problem.